### PR TITLE
Fix self-signed certificate error when connecting to PG

### DIFF
--- a/lib/PostgresDb.js
+++ b/lib/PostgresDb.js
@@ -9,7 +9,9 @@ const pgp = require('pg-promise')({
 
 const PostgresDb = pgp({
   connectionString: process.env.DATABASE_URL,
-  ssl: true
+  ssl: {
+    rejectUnauthorized: false
+  }
 });
 
 module.exports = PostgresDb;


### PR DESCRIPTION
This PR should fix the Postgres connection errors to do with self-signed certificates, as per https://github.com/brianc/node-postgres/issues/2009